### PR TITLE
Retry token creation on transient GitHub API server errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Project-specific guidelines for AI-assisted development of the GitHub Repository
 ### Architectural Decisions
 
 1. **Stateless** - No database or persistent storage, all validation happens per-request
-2. **Fail Fast** - No retries, no fallbacks, immediate error responses
+2. **Fail Fast** - Immediate error responses, no fallbacks. Exception: transient GitHub API server errors (status >= 500) during token creation are retried with exponential backoff
 3. **No Caching** - Fetch fresh data from Secret Manager and GitHub API on every request (exception: JWKS is cached for 1 hour)
 4. **No Observability** - No logging, no metrics, no monitoring (intentional cost/complexity reduction)
 
@@ -96,7 +96,7 @@ Check for these files both at the repository root and in affected subdirectories
 
 - ❌ Logging or monitoring
 - ❌ Caching (tokens, Secret Manager responses, etc.)
-- ❌ Retries or fallback logic
+- ❌ Fallback logic or retries beyond the existing token creation retry (server errors only)
 - ❌ Request deduplication
 - ❌ Health check endpoints
 - ❌ Metrics or observability
@@ -107,7 +107,7 @@ Check for these files both at the repository root and in affected subdirectories
 
 ## Code Style
 
-- **Error handling**: Fail fast, return errors immediately
+- **Error handling**: Fail fast, return errors immediately. Targeted retry with exponential backoff for transient GitHub API server errors (>= 500) during token creation only
 - **Comments**: Only where logic isn't self-evident
 - **Validation**: At system boundaries only (user input, external APIs)
 - **Abstractions**: Avoid creating them for one-time operations

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -266,7 +266,7 @@ token, _, err := client.Apps.CreateInstallationToken(ctx, installationID, opts)
 
 ### Error Handling Strategy
 
-**Fail Fast Philosophy**: Return errors immediately without retries.
+**Fail Fast Philosophy**: Return errors immediately without retries. Exception: transient GitHub API server errors (status >= 500) during token creation are retried up to `maxTokenCreationRetries` (5) times with exponential backoff (`2^attempt` seconds: 1s, 2s, 4s, 8s, 16s). Client errors (403, 422, etc.) and network errors with a non-server response code are never retried.
 
 | Error                    | Status | When                              | Action                     |
 |--------------------------|--------|-----------------------------------|----------------------------|
@@ -280,12 +280,7 @@ token, _, err := client.Apps.CreateInstallationToken(ctx, installationID, opts)
 | Secret Manager error     | 500    | Can't fetch private key           | Reject request             |
 | GitHub API error         | 503    | GitHub unavailable                | Reject request             |
 
-**No retries because**:
-
-- Keeps code simple
-- Errors are usually fatal (wrong config, not transient)
-- GitHub Actions has built-in retry logic
-- Faster failure detection
+**Targeted retries**: Only the `CreateInstallationToken` GitHub API call is retried, and only for server errors (status >= 500) or network errors (nil response). This avoids redundant Secret Manager reads, OIDC validation, and JWT creation that a full-request retry would incur. All other errors (wrong config, insufficient permissions, client errors) fail immediately.
 
 ## Security Considerations
 
@@ -602,7 +597,7 @@ When parsing query parameters:
 
 **Failure Handling**:
 
-- **GitHub API Outage**: Fail fast with 503, rely on caller to retry
+- **GitHub API Outage**: Token creation retries up to 5 times with exponential backoff for server errors (>= 500). If all retries fail, returns 503
 - **Secret Manager Unavailable**: Fail immediately (no caching or fallback)
 - **Archived Repository**: Attempt token issuance anyway; let GitHub API return error if necessary
 - **Suspended GitHub App Installation**: Return 403 with clear error message

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         # Get GitHub OIDC Token
-        RESPONSE=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+        RESPONSE=$(curl -sS --max-time 10 -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
           "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=gh-repo-token-issuer")
         if ! OIDC_TOKEN=$(echo "$RESPONSE" | jq -r '.value // empty' 2>/dev/null) || [[ -z "$OIDC_TOKEN" ]]; then
           echo "Error: Failed to get GitHub OIDC token"
@@ -70,7 +70,7 @@ runs:
         else
           SERVICE_URL="https://gh-repo-token-issuer-db7udto7gq-uk.a.run.app"
         fi
-        RESPONSE=$(curl -sS -X POST \
+        RESPONSE=$(curl -sS --max-time 60 -X POST \
           -H "Authorization: Bearer ${{ steps.oidc.outputs.token }}" \
           -H "Accept: application/json" \
           -H "Content-Length: 0" \

--- a/function/github.go
+++ b/function/github.go
@@ -115,6 +115,8 @@ func GetInstallationID(ctx context.Context, apps GitHubAppsService, repository s
 	return *installation.ID, nil
 }
 
+const maxTokenCreationRetries = 5
+
 // CreateInstallationToken requests an installation access token from GitHub with the specified permissions.
 func CreateInstallationToken(ctx context.Context, apps GitHubAppsService, installationID int64, scopes map[string]string) (*github.InstallationToken, error) {
 	// Build permissions map
@@ -180,15 +182,43 @@ func CreateInstallationToken(ctx context.Context, apps GitHubAppsService, instal
 		Permissions: permissions,
 	}
 
-	token, resp, err := apps.CreateInstallationToken(ctx, installationID, opts)
-	if err != nil {
+	var token *github.InstallationToken
+	var lastErr error
+
+	for attempt := range maxTokenCreationRetries {
+		var resp *github.Response
+		token, resp, lastErr = apps.CreateInstallationToken(ctx, installationID, opts)
+		if lastErr == nil {
+			break
+		}
+
 		if resp != nil && resp.StatusCode == http.StatusForbidden {
 			return nil, fmt.Errorf("insufficient permissions for requested scopes")
 		}
 		if resp != nil && resp.StatusCode == http.StatusUnprocessableEntity {
 			return nil, fmt.Errorf("GitHub App installation is suspended or has insufficient permissions")
 		}
-		return nil, fmt.Errorf("failed to create installation token: %w", err)
+
+		// Retry on server errors (>= 500) or network errors (nil response)
+		retryable := resp == nil || resp.StatusCode >= http.StatusInternalServerError
+		if !retryable {
+			return nil, fmt.Errorf("failed to create installation token: %w", lastErr)
+		}
+
+		if attempt < maxTokenCreationRetries-1 {
+			backoff := time.Duration(1<<uint(attempt)) * time.Second
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed to create installation token: %w", lastErr)
 	}
 
 	// Verify that GitHub granted all requested scopes

--- a/function/github.go
+++ b/function/github.go
@@ -117,6 +117,8 @@ func GetInstallationID(ctx context.Context, apps GitHubAppsService, repository s
 
 const maxTokenCreationRetries = 5
 
+var retryBackoffBase = time.Second
+
 // CreateInstallationToken requests an installation access token from GitHub with the specified permissions.
 func CreateInstallationToken(ctx context.Context, apps GitHubAppsService, installationID int64, scopes map[string]string) (*github.InstallationToken, error) {
 	// Build permissions map
@@ -206,7 +208,7 @@ func CreateInstallationToken(ctx context.Context, apps GitHubAppsService, instal
 		}
 
 		if attempt < maxTokenCreationRetries-1 {
-			backoff := time.Duration(1<<uint(attempt)) * time.Second
+			backoff := time.Duration(1<<uint(attempt)) * retryBackoffBase
 			timer := time.NewTimer(backoff)
 			select {
 			case <-ctx.Done():

--- a/function/github_test.go
+++ b/function/github_test.go
@@ -644,6 +644,8 @@ func TestGetInstallationID(t *testing.T) {
 //  3. Verify returned token matches expected value
 //  4. Verify error handling for various failure scenarios
 func TestCreateInstallationToken(t *testing.T) {
+	retryBackoffBase = time.Millisecond
+	t.Cleanup(func() { retryBackoffBase = time.Second })
 	ctx := context.Background()
 	testTime := time.Now().Add(1 * time.Hour)
 
@@ -779,6 +781,8 @@ func TestCreateInstallationToken(t *testing.T) {
 }
 
 func TestCreateInstallationToken_RetryOn500(t *testing.T) {
+	retryBackoffBase = time.Millisecond
+	t.Cleanup(func() { retryBackoffBase = time.Second })
 	ctx := context.Background()
 	testTime := time.Now().Add(1 * time.Hour)
 	callCount := 0
@@ -810,6 +814,8 @@ func TestCreateInstallationToken_RetryOn500(t *testing.T) {
 }
 
 func TestCreateInstallationToken_RetryOn504(t *testing.T) {
+	retryBackoffBase = time.Millisecond
+	t.Cleanup(func() { retryBackoffBase = time.Second })
 	ctx := context.Background()
 	testTime := time.Now().Add(1 * time.Hour)
 	callCount := 0
@@ -841,6 +847,8 @@ func TestCreateInstallationToken_RetryOn504(t *testing.T) {
 }
 
 func TestCreateInstallationToken_RetriesExhausted(t *testing.T) {
+	retryBackoffBase = time.Millisecond
+	t.Cleanup(func() { retryBackoffBase = time.Second })
 	ctx := context.Background()
 	callCount := 0
 

--- a/function/github_test.go
+++ b/function/github_test.go
@@ -742,17 +742,14 @@ func TestCreateInstallationToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Step 1: Create mock service
 			mock := &mockAppsService{
 				createInstallationToken: func(ctx context.Context, id int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error) {
 					return tt.mockToken, tt.mockResp, tt.mockErr
 				},
 			}
 
-			// Step 2: Call CreateInstallationToken
 			token, err := CreateInstallationToken(ctx, mock, tt.installID, tt.scopes)
 
-			// Step 3 & 4: Verify results
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("CreateInstallationToken() error = nil, wantErr = true")
@@ -778,5 +775,130 @@ func TestCreateInstallationToken(t *testing.T) {
 				t.Errorf("CreateInstallationToken() token = %v, want %v", token.GetToken(), tt.mockToken.GetToken())
 			}
 		})
+	}
+}
+
+func TestCreateInstallationToken_RetryOn500(t *testing.T) {
+	ctx := context.Background()
+	testTime := time.Now().Add(1 * time.Hour)
+	callCount := 0
+
+	mock := &mockAppsService{
+		createInstallationToken: func(ctx context.Context, id int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}}, fmt.Errorf("internal server error")
+			}
+			return &github.InstallationToken{
+				Token:       github.Ptr("ghs_retry_success"),
+				ExpiresAt:   &github.Timestamp{Time: testTime},
+				Permissions: &github.InstallationPermissions{Contents: github.Ptr("write")},
+			}, &github.Response{Response: &http.Response{StatusCode: http.StatusCreated}}, nil
+		},
+	}
+
+	token, err := CreateInstallationToken(ctx, mock, 12345, map[string]string{"contents": "write"})
+	if err != nil {
+		t.Fatalf("CreateInstallationToken() unexpected error = %v", err)
+	}
+	if token.GetToken() != "ghs_retry_success" {
+		t.Errorf("CreateInstallationToken() token = %v, want ghs_retry_success", token.GetToken())
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestCreateInstallationToken_RetryOn504(t *testing.T) {
+	ctx := context.Background()
+	testTime := time.Now().Add(1 * time.Hour)
+	callCount := 0
+
+	mock := &mockAppsService{
+		createInstallationToken: func(ctx context.Context, id int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusGatewayTimeout}}, fmt.Errorf("gateway timeout")
+			}
+			return &github.InstallationToken{
+				Token:       github.Ptr("ghs_retry_504"),
+				ExpiresAt:   &github.Timestamp{Time: testTime},
+				Permissions: &github.InstallationPermissions{Contents: github.Ptr("write")},
+			}, &github.Response{Response: &http.Response{StatusCode: http.StatusCreated}}, nil
+		},
+	}
+
+	token, err := CreateInstallationToken(ctx, mock, 12345, map[string]string{"contents": "write"})
+	if err != nil {
+		t.Fatalf("CreateInstallationToken() unexpected error = %v", err)
+	}
+	if token.GetToken() != "ghs_retry_504" {
+		t.Errorf("CreateInstallationToken() token = %v, want ghs_retry_504", token.GetToken())
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestCreateInstallationToken_RetriesExhausted(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	mock := &mockAppsService{
+		createInstallationToken: func(ctx context.Context, id int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error) {
+			callCount++
+			return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}}, fmt.Errorf("persistent server error")
+		},
+	}
+
+	_, err := CreateInstallationToken(ctx, mock, 12345, map[string]string{"contents": "write"})
+	if err == nil {
+		t.Fatal("CreateInstallationToken() expected error after retries exhausted")
+	}
+	if !strings.Contains(err.Error(), "failed to create installation token") {
+		t.Errorf("CreateInstallationToken() error = %v, want containing 'failed to create installation token'", err)
+	}
+	if callCount != maxTokenCreationRetries {
+		t.Errorf("expected %d calls, got %d", maxTokenCreationRetries, callCount)
+	}
+}
+
+func TestCreateInstallationToken_NoRetryOn403(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	mock := &mockAppsService{
+		createInstallationToken: func(ctx context.Context, id int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error) {
+			callCount++
+			return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusForbidden}}, fmt.Errorf("forbidden")
+		},
+	}
+
+	_, err := CreateInstallationToken(ctx, mock, 12345, map[string]string{"contents": "write"})
+	if err == nil {
+		t.Fatal("CreateInstallationToken() expected error on 403")
+	}
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 call (no retry), got %d", callCount)
+	}
+}
+
+func TestCreateInstallationToken_NoRetryOn422(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	mock := &mockAppsService{
+		createInstallationToken: func(ctx context.Context, id int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error) {
+			callCount++
+			return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusUnprocessableEntity}}, fmt.Errorf("unprocessable")
+		},
+	}
+
+	_, err := CreateInstallationToken(ctx, mock, 12345, map[string]string{"contents": "write"})
+	if err == nil {
+		t.Fatal("CreateInstallationToken() expected error on 422")
+	}
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 call (no retry), got %d", callCount)
 	}
 }

--- a/function/handlers.go
+++ b/function/handlers.go
@@ -37,7 +37,7 @@ func TokenHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
 
 	// Extract GitHub OIDC token from Authorization header (Bearer token)


### PR DESCRIPTION
## Summary

GitHub API occasionally returns transient 5xx errors during token creation, causing unnecessary workflow failures that require manual re-runs. This adds exponential backoff retries (up to 5 attempts) for server errors only, while preserving fail-fast behavior for client errors.