### PR TITLE
Retry installation lookup on transient GitHub API errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Project-specific guidelines for AI-assisted development of the GitHub Repository
 ### Architectural Decisions
 
 1. **Stateless** - No database or persistent storage, all validation happens per-request
-2. **Fail Fast** - Immediate error responses, no fallbacks. Exception: transient GitHub API server errors (status >= 500) during token creation are retried with exponential backoff
+2. **Fail Fast** - Immediate error responses, no fallbacks. Exception: transient GitHub API server errors (status >= 500) and network errors during installation lookup and token creation are retried with exponential backoff
 3. **No Caching** - Fetch fresh data from Secret Manager and GitHub API on every request (exception: JWKS is cached for 1 hour)
 4. **No Observability** - No logging, no metrics, no monitoring (intentional cost/complexity reduction)
 
@@ -96,7 +96,7 @@ Check for these files both at the repository root and in affected subdirectories
 
 - ❌ Logging or monitoring
 - ❌ Caching (tokens, Secret Manager responses, etc.)
-- ❌ Fallback logic or retries beyond the existing token creation retry (server errors only)
+- ❌ Fallback logic or retries beyond the existing GitHub API retries (server/network errors only)
 - ❌ Request deduplication
 - ❌ Health check endpoints
 - ❌ Metrics or observability
@@ -107,7 +107,7 @@ Check for these files both at the repository root and in affected subdirectories
 
 ## Code Style
 
-- **Error handling**: Fail fast, return errors immediately. Targeted retry with exponential backoff for transient GitHub API server errors (>= 500) during token creation only
+- **Error handling**: Fail fast, return errors immediately. Targeted retry with exponential backoff for transient GitHub API server errors (>= 500) and network errors during installation lookup and token creation
 - **Comments**: Only where logic isn't self-evident
 - **Validation**: At system boundaries only (user input, external APIs)
 - **Abstractions**: Avoid creating them for one-time operations

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -266,7 +266,7 @@ token, _, err := client.Apps.CreateInstallationToken(ctx, installationID, opts)
 
 ### Error Handling Strategy
 
-**Fail Fast Philosophy**: Return errors immediately without retries. Exception: transient GitHub API server errors (status >= 500) during token creation are retried up to `maxTokenCreationRetries` (5) times with exponential backoff (`2^attempt` seconds: 1s, 2s, 4s, 8s, 16s). Client errors (403, 422, etc.) and network errors with a non-server response code are never retried.
+**Fail Fast Philosophy**: Return errors immediately without retries. Exception: transient GitHub API errors during installation lookup and token creation are retried up to `maxRetries` (5) times with exponential backoff (`2^attempt` seconds: 1s, 2s, 4s, 8s, 16s). Client errors (403, 422, etc.) are never retried.
 
 | Error                    | Status | When                              | Action                     |
 |--------------------------|--------|-----------------------------------|----------------------------|
@@ -280,7 +280,7 @@ token, _, err := client.Apps.CreateInstallationToken(ctx, installationID, opts)
 | Secret Manager error     | 500    | Can't fetch private key           | Reject request             |
 | GitHub API error         | 503    | GitHub unavailable                | Reject request             |
 
-**Targeted retries**: Only the `CreateInstallationToken` GitHub API call is retried, and only for server errors (status >= 500) or network errors (nil response). This avoids redundant Secret Manager reads, OIDC validation, and JWT creation that a full-request retry would incur. All other errors (wrong config, insufficient permissions, client errors) fail immediately.
+**Targeted retries**: Both `FindRepositoryInstallation` and `CreateInstallationToken` GitHub API calls are retried on server errors (status >= 500) or network errors (nil response). This avoids redundant Secret Manager reads, OIDC validation, and JWT creation that a full-request retry would incur. All other errors (wrong config, insufficient permissions, client errors) fail immediately.
 
 ## Security Considerations
 
@@ -597,7 +597,7 @@ When parsing query parameters:
 
 **Failure Handling**:
 
-- **GitHub API Outage**: Token creation retries up to 5 times with exponential backoff for server errors (>= 500). If all retries fail, returns 503
+- **GitHub API Outage**: Installation lookup and token creation retry up to 5 times with exponential backoff for server errors (>= 500) or network errors. If all retries fail, returns 503
 - **Secret Manager Unavailable**: Fail immediately (no caching or fallback)
 - **Archived Repository**: Attempt token issuance anyway; let GitHub API return error if necessary
 - **Suspended GitHub App Installation**: Return 403 with clear error message

--- a/function/github.go
+++ b/function/github.go
@@ -100,12 +100,39 @@ func GetInstallationID(ctx context.Context, apps GitHubAppsService, repository s
 
 	owner, repo := parts[0], parts[1]
 
-	installation, resp, err := apps.FindRepositoryInstallation(ctx, owner, repo)
-	if err != nil {
+	var installation *github.Installation
+	var lastErr error
+
+	for attempt := range maxRetries {
+		var resp *github.Response
+		installation, resp, lastErr = apps.FindRepositoryInstallation(ctx, owner, repo)
+		if lastErr == nil {
+			break
+		}
+
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return 0, fmt.Errorf("GitHub App is not installed on repository %s", repository)
 		}
-		return 0, fmt.Errorf("failed to find installation: %w", err)
+
+		retryable := resp == nil || resp.StatusCode >= http.StatusInternalServerError
+		if !retryable {
+			return 0, fmt.Errorf("failed to find installation: %w", lastErr)
+		}
+
+		if attempt < maxRetries-1 {
+			backoff := time.Duration(1<<uint(attempt)) * retryBackoffBase
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return 0, ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+
+	if lastErr != nil {
+		return 0, fmt.Errorf("failed to find installation: %w", lastErr)
 	}
 
 	if installation == nil || installation.ID == nil {
@@ -115,7 +142,7 @@ func GetInstallationID(ctx context.Context, apps GitHubAppsService, repository s
 	return *installation.ID, nil
 }
 
-const maxTokenCreationRetries = 5
+const maxRetries = 5
 
 var retryBackoffBase = time.Second
 
@@ -187,7 +214,7 @@ func CreateInstallationToken(ctx context.Context, apps GitHubAppsService, instal
 	var token *github.InstallationToken
 	var lastErr error
 
-	for attempt := range maxTokenCreationRetries {
+	for attempt := range maxRetries {
 		var resp *github.Response
 		token, resp, lastErr = apps.CreateInstallationToken(ctx, installationID, opts)
 		if lastErr == nil {
@@ -207,7 +234,7 @@ func CreateInstallationToken(ctx context.Context, apps GitHubAppsService, instal
 			return nil, fmt.Errorf("failed to create installation token: %w", lastErr)
 		}
 
-		if attempt < maxTokenCreationRetries-1 {
+		if attempt < maxRetries-1 {
 			backoff := time.Duration(1<<uint(attempt)) * retryBackoffBase
 			timer := time.NewTimer(backoff)
 			select {

--- a/function/github_test.go
+++ b/function/github_test.go
@@ -580,11 +580,11 @@ func TestGetInstallationID(t *testing.T) {
 			errContains:  "not installed",
 		},
 		{
-			name:         "API error",
+			name:         "API error - non-retryable",
 			repository:   "owner/repo",
 			mockResponse: nil,
-			mockResp:     &github.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}},
-			mockErr:      fmt.Errorf("internal server error"),
+			mockResp:     &github.Response{Response: &http.Response{StatusCode: http.StatusBadRequest}},
+			mockErr:      fmt.Errorf("bad request"),
 			wantErr:      true,
 			errContains:  "failed to find installation",
 		},
@@ -632,6 +632,109 @@ func TestGetInstallationID(t *testing.T) {
 				t.Errorf("GetInstallationID() = %v, want %v", gotID, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestGetInstallationID_RetryOnNetworkError(t *testing.T) {
+	retryBackoffBase = time.Millisecond
+	t.Cleanup(func() { retryBackoffBase = time.Second })
+	ctx := context.Background()
+	callCount := 0
+
+	mock := &mockAppsService{
+		findRepoInstallation: func(ctx context.Context, owner, repo string) (*github.Installation, *github.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, nil, fmt.Errorf("net/http: TLS handshake timeout")
+			}
+			return &github.Installation{ID: github.Ptr(int64(12345))},
+				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}}, nil
+		},
+	}
+
+	gotID, err := GetInstallationID(ctx, mock, "owner/repo")
+	if err != nil {
+		t.Fatalf("GetInstallationID() unexpected error = %v", err)
+	}
+	if gotID != 12345 {
+		t.Errorf("GetInstallationID() = %v, want 12345", gotID)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestGetInstallationID_RetryOn500(t *testing.T) {
+	retryBackoffBase = time.Millisecond
+	t.Cleanup(func() { retryBackoffBase = time.Second })
+	ctx := context.Background()
+	callCount := 0
+
+	mock := &mockAppsService{
+		findRepoInstallation: func(ctx context.Context, owner, repo string) (*github.Installation, *github.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}}, fmt.Errorf("internal server error")
+			}
+			return &github.Installation{ID: github.Ptr(int64(12345))},
+				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}}, nil
+		},
+	}
+
+	gotID, err := GetInstallationID(ctx, mock, "owner/repo")
+	if err != nil {
+		t.Fatalf("GetInstallationID() unexpected error = %v", err)
+	}
+	if gotID != 12345 {
+		t.Errorf("GetInstallationID() = %v, want 12345", gotID)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestGetInstallationID_RetriesExhausted(t *testing.T) {
+	retryBackoffBase = time.Millisecond
+	t.Cleanup(func() { retryBackoffBase = time.Second })
+	ctx := context.Background()
+	callCount := 0
+
+	mock := &mockAppsService{
+		findRepoInstallation: func(ctx context.Context, owner, repo string) (*github.Installation, *github.Response, error) {
+			callCount++
+			return nil, nil, fmt.Errorf("persistent network error")
+		},
+	}
+
+	_, err := GetInstallationID(ctx, mock, "owner/repo")
+	if err == nil {
+		t.Fatal("GetInstallationID() expected error after retries exhausted")
+	}
+	if !strings.Contains(err.Error(), "failed to find installation") {
+		t.Errorf("GetInstallationID() error = %v, want containing 'failed to find installation'", err)
+	}
+	if callCount != maxRetries {
+		t.Errorf("expected %d calls, got %d", maxRetries, callCount)
+	}
+}
+
+func TestGetInstallationID_NoRetryOn404(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	mock := &mockAppsService{
+		findRepoInstallation: func(ctx context.Context, owner, repo string) (*github.Installation, *github.Response, error) {
+			callCount++
+			return nil, &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}, fmt.Errorf("not found")
+		},
+	}
+
+	_, err := GetInstallationID(ctx, mock, "owner/repo")
+	if err == nil {
+		t.Fatal("GetInstallationID() expected error on 404")
+	}
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 call (no retry), got %d", callCount)
 	}
 }
 
@@ -866,8 +969,8 @@ func TestCreateInstallationToken_RetriesExhausted(t *testing.T) {
 	if !strings.Contains(err.Error(), "failed to create installation token") {
 		t.Errorf("CreateInstallationToken() error = %v, want containing 'failed to create installation token'", err)
 	}
-	if callCount != maxTokenCreationRetries {
-		t.Errorf("expected %d calls, got %d", maxTokenCreationRetries, callCount)
+	if callCount != maxRetries {
+		t.Errorf("expected %d calls, got %d", maxRetries, callCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

`GetInstallationID` had no retry logic, so transient failures like TLS handshake timeouts caused immediate request failure. This adds the same retry pattern already used by `CreateInstallationToken`: up to 5 attempts with exponential backoff for server errors (>= 500) and network errors, while client errors (404, 400, etc.) still fail immediately.